### PR TITLE
add a symfony benchmark with custom normalizers

### DIFF
--- a/src/Command/BenchmarkCommand.php
+++ b/src/Command/BenchmarkCommand.php
@@ -10,6 +10,7 @@ use Ivory\Tests\Serializer\Benchmark\Result\BenchmarkResultInterface;
 use Ivory\Tests\Serializer\Benchmark\Runner\BenchmarkRunner;
 use Ivory\Tests\Serializer\Benchmark\SerializardClosureBenchmark;
 use Ivory\Tests\Serializer\Benchmark\SerializardReflectionBenchmark;
+use Ivory\Tests\Serializer\Benchmark\SymfonyCustomNormalizerBenchmark;
 use Ivory\Tests\Serializer\Benchmark\SymfonyGetSetNormalizerBenchmark;
 use Ivory\Tests\Serializer\Benchmark\SymfonyObjectNormalizerBenchmark;
 use Symfony\Component\Console\Command\Command;
@@ -71,6 +72,7 @@ class BenchmarkCommand extends Command
         } else {
             $benchmarks = [
                 new IvoryBenchmark(),
+                new SymfonyCustomNormalizerBenchmark(),
                 new SymfonyObjectNormalizerBenchmark(),
                 new SymfonyGetSetNormalizerBenchmark(),
                 new JmsBenchmark(),

--- a/src/SymfonyCustomNormalizerBenchmark.php
+++ b/src/SymfonyCustomNormalizerBenchmark.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Ivory\Tests\Serializer\Benchmark;
+
+use Ivory\Tests\Serializer\Benchmark\Model\Category;
+use Ivory\Tests\Serializer\Benchmark\Model\Comment;
+use Ivory\Tests\Serializer\Benchmark\Model\Forum;
+use Ivory\Tests\Serializer\Benchmark\Model\Thread;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Encoder\YamlEncoder;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
+
+class SymfonyCustomNormalizerBenchmark extends AbstractBenchmark
+{
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->serializer = new Serializer([
+            new DateTimeNormalizer(),
+            new class implements NormalizerInterface, CacheableSupportsMethodInterface
+            {
+                public function hasCacheableSupportsMethod(): bool
+                {
+                    return true;
+                }
+
+                public function normalize($object, $format = null, array $context = array())
+                {
+                    assert($object instanceof Forum);
+
+                    return [
+                        'id' => $object->getId(),
+                        'name' => $object->getName(),
+                        'threads' => $object->getThreads(),
+                        'category' => $object->getCategory(),
+                        'createdAt' => $object->getCreatedAt(),
+                        'updatedAt' => $object->getUpdatedAt(),
+                    ];
+                }
+
+                public function supportsNormalization($data, $format = null)
+                {
+                    return $data instanceof Forum;
+                }
+            },
+            new class implements NormalizerInterface, CacheableSupportsMethodInterface
+            {
+                public function hasCacheableSupportsMethod(): bool
+                {
+                    return true;
+                }
+
+                public function normalize($object, $format = null, array $context = array())
+                {
+                    assert($object instanceof Thread);
+
+                    return [
+                        'id' => $object->getId(),
+                        'popularity' => $object->getPopularity(),
+                        'title' => $object->getTitle(),
+                        'comments' => $object->getComments(),
+                        'description' => $object->getDescription(),
+                        'createdAt' => $object->getCreatedAt(),
+                        'updatedAt' => $object->getUpdatedAt(),
+                    ];
+                }
+
+                public function supportsNormalization($data, $format = null)
+                {
+                    return $data instanceof Thread;
+                }
+            },
+            new class implements NormalizerInterface, CacheableSupportsMethodInterface
+            {
+                public function hasCacheableSupportsMethod(): bool
+                {
+                    return true;
+                }
+
+                public function normalize($object, $format = null, array $context = array())
+                {
+                    assert($object instanceof Comment);
+
+                    return [
+                        'id' => $object->getId(),
+                        'content' => $object->getContent(),
+                        'author' => $object->getAuthor(),
+                        'createdAt' => $object->getCreatedAt(),
+                        'updatedAt' => $object->getUpdatedAt(),
+                    ];
+                }
+
+                public function supportsNormalization($data, $format = null)
+                {
+                    return $data instanceof Comment;
+                }
+            },
+            new class implements NormalizerInterface, CacheableSupportsMethodInterface
+            {
+                public function hasCacheableSupportsMethod(): bool
+                {
+                    return true;
+                }
+
+                public function normalize($object, $format = null, array $context = array())
+                {
+                    assert($object instanceof Category);
+
+                    return [
+                        'id' => $object->getId(),
+                        'parent' => $object->getParent(),
+                        'children' => $object->getChildren(),
+                        'createdAt' => $object->getCreatedAt(),
+                        'updatedAt' => $object->getUpdatedAt(),
+                    ];
+                }
+
+                public function supportsNormalization($data, $format = null)
+                {
+                    return $data instanceof Category;
+                }
+            },
+        ], [
+            new JsonEncoder(), new XmlEncoder(), new YamlEncoder()
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute($horizontalComplexity = 1, $verticalComplexity = 1)
+    {
+        return $this->serializer->serialize(
+            $this->getData($horizontalComplexity, $verticalComplexity),
+            $this->getFormat()
+        );
+    }
+}


### PR DESCRIPTION
I've half added this as I was intrigued to how it would perform, after I saw `SerializardClosureBenchmark`.

I'm not even entirely sure that I agree with this being included (as well as `SerializardClosureBenchmark`), as it makes the benchmarks non-comparable. You can't compare this new benchmark with the JMS benchmarks for example, as it's just comparing apples with pears - they are not doing the same thing. Unless ofcourse you added a JMS benchmark with custom handlers, like this one.

Edit: faster than `JsonSerializableBenchmark` - funny.