### PR TITLE
Specify the most important columns

### DIFF
--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -5,6 +5,7 @@
         "bench": {
             "extends": "aggregate",
             "break": ["params"],
+            "cols": [ "suite", "benchmark", "mean", "diff", "worst", "best", "mem_real" ],
             "sort": {"mean": "asc"}
         }
     }


### PR DESCRIPTION
This PR specifies the most important columns to analyze the results. The default ones adds a lot of information on the console and make reading difficult.